### PR TITLE
render diplodoc notes

### DIFF
--- a/__tests__/rules/diplodoc/__fixtures__/index.ts
+++ b/__tests__/rules/diplodoc/__fixtures__/index.ts
@@ -1,0 +1,14 @@
+import {notes} from './notes';
+
+export type SpecEntry = {
+    markdown: string;
+    expectedMarkdown?: string;
+    section: string;
+    number: number;
+    html: string;
+};
+
+const tests: SpecEntry[] = [...notes];
+
+export {tests};
+export default {tests};

--- a/__tests__/rules/diplodoc/__fixtures__/notes.ts
+++ b/__tests__/rules/diplodoc/__fixtures__/notes.ts
@@ -1,0 +1,167 @@
+const notes = [
+    {
+        markdown: `\
+{% note info %}
+
+note info
+
+{% endnote %}`,
+        expectedMarkdown: `\
+{% note info "Note" %}
+
+note info
+
+{% endnote %}`,
+        html: '',
+        section: 'notes',
+        number: 1,
+    },
+    {
+        markdown: `\
+{% note info %}
+
+note info
+
+{% endnote %}
+
+outside content`,
+        expectedMarkdown: `\
+{% note info "Note" %}
+
+note info
+
+{% endnote %}
+
+outside content`,
+        html: '',
+        section: 'notes',
+        number: 2,
+    },
+    {
+        markdown: `\
+outside content
+
+{% note info %}
+
+note info
+
+{% endnote %}`,
+        expectedMarkdown: `\
+outside content
+
+{% note info "Note" %}
+
+note info
+
+{% endnote %}`,
+        html: '',
+        section: 'notes',
+        number: 3,
+    },
+    {
+        markdown: `\
+{% note tip %}
+
+note tip
+
+{% endnote %}`,
+        expectedMarkdown: `\
+{% note tip "Tip" %}
+
+note tip
+
+{% endnote %}`,
+        html: '',
+        section: 'notes',
+        number: 4,
+    },
+    {
+        markdown: `\
+{% note warning %}
+
+note warning
+
+{% endnote %}`,
+        expectedMarkdown: `\
+{% note warning "Warning" %}
+
+note warning
+
+{% endnote %}`,
+        html: '',
+        section: 'notes',
+        number: 5,
+    },
+    {
+        markdown: `\
+{% note alert %}
+
+note alert
+
+{% endnote %}`,
+        expectedMarkdown: `\
+{% note alert "Alert" %}
+
+note alert
+
+{% endnote %}`,
+        html: '',
+        section: 'notes',
+        number: 6,
+    },
+    {
+        markdown: `\
+{% note info "custom header" %}
+
+note with custom header
+
+{% endnote %}`,
+        html: '',
+        section: 'notes',
+        number: 7,
+    },
+    {
+        markdown: `\
+{% note info "" %}
+
+note with empty title
+
+{% endnote %}`,
+        html: '',
+        section: 'notes',
+        number: 8,
+    },
+    {
+        markdown: `\
+{% note info "" %}
+
+- list item one
+- list item two
+
+{% endnote %}`,
+        html: '',
+        section: 'notes',
+        number: 9,
+    },
+    // TODO: pr into transform to preserve note's map
+    // mappings are needed to render content inside other containers
+    /*
+    {
+        markdown: `\
+- parent list item
+
+  {% note info "" %}
+
+  - list item one
+  - list item two
+
+  {% endnote %}`,
+        html: '',
+        section: 'notes',
+        number: 9,
+    },
+    */
+];
+
+export {notes};
+export default {notes};

--- a/__tests__/rules/diplodoc/__fixtures__/notes.ts
+++ b/__tests__/rules/diplodoc/__fixtures__/notes.ts
@@ -143,24 +143,50 @@ note with empty title
         section: 'notes',
         number: 9,
     },
-    // TODO: pr into transform to preserve note's map
-    // mappings are needed to render content inside other containers
-    /*
     {
         markdown: `\
-- parent list item
+- parent
+  - nested list item
 
-  {% note info "" %}
+    {% note info "" %}
 
-  - list item one
-  - list item two
+    - list item one
+    - list item two
 
-  {% endnote %}`,
+    {% endnote %}`,
         html: '',
         section: 'notes',
-        number: 9,
+        number: 10,
     },
-    */
+    {
+        markdown: `\
+1. something 1
+   1. other 1
+
+      {% note info "" %}
+
+      - content
+
+      {% endnote %}
+   2. other 2
+2. something 2`,
+        expectedMarkdown: `\
+1. something 1
+   1. other 1
+
+      {% note info "" %}
+
+      - content
+
+      {% endnote %}
+
+
+   2. other 2
+2. something 2`,
+        html: '',
+        section: 'notes',
+        number: 11,
+    },
 ];
 
 export {notes};

--- a/__tests__/rules/diplodoc/diplodoc.units.ts
+++ b/__tests__/rules/diplodoc/diplodoc.units.ts
@@ -1,0 +1,31 @@
+// @ts-ignore
+import MarkdownIt from 'markdown-it';
+// @ts-ignore
+import notes from '@doc-tools/transform/lib/plugins/notes';
+
+import {MarkdownRendererEnv} from '../../../src/renderer';
+import {mdRenderer} from '../../../src/plugin';
+import {tests, SpecEntry} from './__fixtures__';
+
+import {normalizeMD} from '../../__helpers__';
+
+const md = new MarkdownIt('commonmark', {html: true});
+
+md.use(notes, {lang: 'en'});
+md.use(mdRenderer);
+
+describe('diplodoc', () => {
+    tests.forEach(({section, number, markdown, expectedMarkdown}: SpecEntry) => {
+        const name = `${section} ${number}`;
+
+        test(name, () => {
+            const env: MarkdownRendererEnv = {source: markdown.split('\n')};
+            const rendered = normalizeMD(md.render(markdown, env));
+            // expected render is the original markdown
+            // fallbacks to specified expectedMarkdown fixture
+            const expected = normalizeMD(expectedMarkdown ?? markdown);
+
+            expect(rendered).toStrictEqual(expected);
+        });
+    });
+});

--- a/__tests__/rules/diplodoc/diplodoc.units.ts
+++ b/__tests__/rules/diplodoc/diplodoc.units.ts
@@ -26,6 +26,8 @@ describe('diplodoc', () => {
             const expected = normalizeMD(expectedMarkdown ?? markdown);
 
             expect(rendered).toStrictEqual(expected);
+
+            console.log(rendered);
         });
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -630,6 +630,72 @@
       "resolved": "https://registry.npmjs.org/@diplodoc/markdown-it-custom-renderer/-/markdown-it-custom-renderer-0.0.1.tgz",
       "integrity": "sha512-CuCzY7k56FsjBl9HWAesDRcLfIm5tPlPH6Mgjh0u8SJpthvE+psx5FxWu1Czu/KqfV/bxdeOFmRZ7CChw4qbUg=="
     },
+    "@doc-tools/transform": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@doc-tools/transform/-/transform-3.0.0.tgz",
+      "integrity": "sha512-Q9iq8kZsvEKyLxIQmCvm3ioc8jYgTq36q10TDctIfNzgIKb1+Uhy8EA+LK/jYXur13gaHE9D5sfiuzuj+vSYYg==",
+      "requires": {
+        "chalk": "4.1.2",
+        "get-root-node-polyfill": "1.0.0",
+        "github-slugger": "1.4.0",
+        "lodash": "4.17.21",
+        "markdown-it": "13.0.1",
+        "markdown-it-attrs": "4.1.4",
+        "markdown-it-deflist": "2.1.0",
+        "markdown-it-meta": "0.0.1",
+        "markdown-it-sup": "1.0.0",
+        "markdownlint": "^0.25.1",
+        "markdownlint-rule-helpers": "0.17.2",
+        "postcss": "8.4.16",
+        "sanitize-html": "2.7.3",
+        "slugify": "1.6.5"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@es-exec/api": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@es-exec/api/-/api-0.0.5.tgz",
@@ -2280,8 +2346,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -2807,8 +2872,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-properties": {
       "version": "1.1.4",
@@ -2891,6 +2955,46 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.137",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
@@ -2921,8 +3025,7 @@
     "entities": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "dev": true
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3648,8 +3751,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -4174,6 +4276,11 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
+    "get-root-node-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-root-node-polyfill/-/get-root-node-polyfill-1.0.0.tgz",
+      "integrity": "sha512-AzucsG1DdepagLF8tkxfjUqn3cCQ63MgH/tBWwPSy0BIDt8iLFZYDwnTxA08d+zdgL8l2dkPdZDe+Qkd+RMl9Q=="
+    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -4195,6 +4302,11 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true
+    },
+    "github-slugger": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
+      "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ=="
     },
     "glob": {
       "version": "7.2.3",
@@ -4353,6 +4465,24 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        }
+      }
     },
     "human-signals": {
       "version": "2.1.0",
@@ -6326,7 +6456,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
       "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-      "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -6339,6 +6468,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -6401,7 +6535,6 @@
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
       "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1",
         "entities": "~3.0.1",
@@ -6410,11 +6543,92 @@
         "uc.micro": "^1.0.5"
       }
     },
+    "markdown-it-attrs": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.1.4.tgz",
+      "integrity": "sha512-53Zfv8PTb6rlVFDlD106xcZHKBSsRZKJ2IW/rTxEJBEVbVaoxaNsmRkG0HXfbHl2SK8kaxZ2QKqdthWy/QBwmA=="
+    },
+    "markdown-it-deflist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz",
+      "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg=="
+    },
+    "markdown-it-meta": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-meta/-/markdown-it-meta-0.0.1.tgz",
+      "integrity": "sha512-sCQG7mHJM3i4l6MztgzxE8t3aTQB5CSCO0wq8k6CEaqud40eryWXqPesq5AyztbYgwnxJcNIsmFsKDRkrl6Zuw==",
+      "requires": {
+        "js-yaml": "^3.8.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
+    "markdown-it-sup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-1.0.0.tgz",
+      "integrity": "sha512-E32m0nV9iyhRR7CrhnzL5msqic7rL1juWre6TQNxsnApg7Uf+F97JOKxUijg5YwXz86lZ0mqfOnutoryyNdntQ=="
+    },
+    "markdownlint": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
+      "requires": {
+        "markdown-it": "12.3.2"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        },
+        "linkify-it": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+          "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
+        },
+        "markdown-it": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+          "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "~2.1.0",
+            "linkify-it": "^3.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        }
+      }
+    },
+    "markdownlint-rule-helpers": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.17.2.tgz",
+      "integrity": "sha512-XaeoW2NYSlWxMCZM2B3H7YTG6nlaLfkEZWMBhr4hSPlq9MuY2sy83+Xr89jXOqZMZYjvi5nBCGoFh7hHoPKZmA=="
+    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "dev": true
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -6485,6 +6699,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -6749,6 +6968,11 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -6788,8 +7012,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -6856,6 +7079,16 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "dev": true
+    },
+    "postcss": {
+      "version": "8.4.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "requires": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -7328,6 +7561,31 @@
         }
       }
     },
+    "sanitize-html": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.3.tgz",
+      "integrity": "sha512-jMaHG29ak4miiJ8wgqA1849iInqORgNv7SLfSw9LtfOhEUQ1C0YHKH73R+hgyufBW9ZFeJrb057k9hjlfBCVlw==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        }
+      }
+    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -7400,6 +7658,11 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "slugify": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -7529,6 +7792,11 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -7578,8 +7846,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "stack-utils": {
       "version": "2.0.5",
@@ -7901,8 +8168,7 @@
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -631,9 +631,9 @@
       "integrity": "sha512-CuCzY7k56FsjBl9HWAesDRcLfIm5tPlPH6Mgjh0u8SJpthvE+psx5FxWu1Czu/KqfV/bxdeOFmRZ7CChw4qbUg=="
     },
     "@doc-tools/transform": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@doc-tools/transform/-/transform-3.0.0.tgz",
-      "integrity": "sha512-Q9iq8kZsvEKyLxIQmCvm3ioc8jYgTq36q10TDctIfNzgIKb1+Uhy8EA+LK/jYXur13gaHE9D5sfiuzuj+vSYYg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@doc-tools/transform/-/transform-3.0.1.tgz",
+      "integrity": "sha512-77Hzxs6SE54eZLOz+oVVcXKGrSsWkwePgkinX/KZcBuHyEOg8rqpyHNu/pKLBFuDPLjOq2h5EjbzQQ019cs+8w==",
       "requires": {
         "chalk": "4.1.2",
         "get-root-node-polyfill": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "markdown-it": "^13.0.1"
   },
   "dependencies": {
-    "@diplodoc/markdown-it-custom-renderer": "0.0.1"
+    "@diplodoc/markdown-it-custom-renderer": "0.0.1",
+    "@doc-tools/transform": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
   },
   "dependencies": {
     "@diplodoc/markdown-it-custom-renderer": "0.0.1",
-    "@doc-tools/transform": "^3.0.0"
+    "@doc-tools/transform": "^3.0.1"
   }
 }

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -4,6 +4,7 @@ import Token from 'markdown-it/lib/token';
 
 import {inline} from 'src/rules/inline';
 import {block} from 'src/rules/block';
+import {diplodoc} from 'src/rules/diplodoc';
 import {renderEmptyBlockquote, renderBlockquote} from 'src/rules/block/blockquote';
 import list, {
     renderEmptyListItem,
@@ -53,7 +54,7 @@ const initRulesState = () => ({
 });
 
 class MarkdownRenderer<T = {}, CT extends ContainerBase = ContainerBase> extends CustomRenderer<T> {
-    static defaultRules: Renderer.RenderRuleRecord = {...inline, ...block};
+    static defaultRules: Renderer.RenderRuleRecord = {...inline, ...block, ...diplodoc};
     static defaultContainerRenderers: Array<ContainerRenderer<ContainerBase>> = [
         renderEmptyBlockquote,
         renderEmptyListItem,

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -5,7 +5,11 @@ import Token from 'markdown-it/lib/token';
 import {inline} from 'src/rules/inline';
 import {block} from 'src/rules/block';
 import {renderEmptyBlockquote, renderBlockquote} from 'src/rules/block/blockquote';
-import {renderEmptyListItem, renderOrderedList, renderUnorderedList} from 'src/rules/block/list';
+import list, {
+    renderEmptyListItem,
+    renderOrderedList,
+    renderUnorderedList,
+} from 'src/rules/block/list';
 import {
     sameRow,
     aligned,
@@ -45,6 +49,7 @@ const initRulesState = () => ({
     ...heading.initState(),
     ...image.initState(),
     ...link.initState(),
+    ...list.initState(),
 });
 
 class MarkdownRenderer<T = {}, CT extends ContainerBase = ContainerBase> extends CustomRenderer<T> {

--- a/src/rules/diplodoc/index.ts
+++ b/src/rules/diplodoc/index.ts
@@ -1,0 +1,10 @@
+import type Renderer from 'markdown-it/lib/renderer';
+
+import {notes} from './notes';
+
+const diplodoc: Renderer.RenderRuleRecord = {
+    ...notes,
+};
+
+export {diplodoc};
+export default {diplodoc};

--- a/src/rules/diplodoc/notes.ts
+++ b/src/rules/diplodoc/notes.ts
@@ -15,8 +15,7 @@ const notes: Renderer.RenderRuleRecord = {
 
         rendered += this.EOL;
 
-        // todo: preserve notes map inside transform
-        // rendered += this.renderContainer(token);
+        rendered += this.renderContainer(token);
 
         const type = token.attrGet('note-type');
         if (!type?.length) {
@@ -42,15 +41,23 @@ const notes: Renderer.RenderRuleRecord = {
 
         rendered += this.EOL.repeat(2);
 
-        // todo: preserve notes map inside transform
-        // const token = tokens[i];
-        // rendered += this.renderContainer(token);
+        const token = tokens[i];
+
+        rendered += this.renderContainer(token);
 
         rendered += '{% endnote %}';
 
         rendered += this.EOL;
 
-        if (i + 1 !== tokens.length) {
+        const isList = (container: any) =>
+            container?.type === 'ordered_list_open' || container?.type === 'bullet_list_open';
+
+        const epsilon = this.containers.reduce(
+            (acc, container) => (isList(container) ? acc + 2 : 0),
+            1,
+        );
+
+        if (i + epsilon !== tokens.length) {
             rendered += this.EOL;
         }
 

--- a/src/rules/diplodoc/notes.ts
+++ b/src/rules/diplodoc/notes.ts
@@ -2,6 +2,7 @@ import Renderer from 'markdown-it/lib/renderer';
 import Token from 'markdown-it/lib/token';
 
 import {MarkdownRenderer} from 'src/renderer';
+import {isList} from 'src/rules/block/list';
 
 const notes: Renderer.RenderRuleRecord = {
     yfm_note_open: function (this: MarkdownRenderer, tokens: Token[], i: number) {
@@ -49,15 +50,8 @@ const notes: Renderer.RenderRuleRecord = {
 
         rendered += this.EOL;
 
-        const isList = (container: any) =>
-            container?.type === 'ordered_list_open' || container?.type === 'bullet_list_open';
-
-        const epsilon = this.containers.reduce(
-            (acc, container) => (isList(container) ? acc + 2 : 0),
-            1,
-        );
-
-        if (i + epsilon !== tokens.length) {
+        const closeTokens = this.containers.reduce((n, token) => (isList(token) ? n + 2 : 0), 0);
+        if (i + closeTokens + 1 !== tokens.length) {
             rendered += this.EOL;
         }
 

--- a/src/rules/diplodoc/notes.ts
+++ b/src/rules/diplodoc/notes.ts
@@ -1,0 +1,62 @@
+import Renderer from 'markdown-it/lib/renderer';
+import Token from 'markdown-it/lib/token';
+
+import {MarkdownRenderer} from 'src/renderer';
+
+const notes: Renderer.RenderRuleRecord = {
+    yfm_note_open: function (this: MarkdownRenderer, tokens: Token[], i: number) {
+        const token = tokens[i];
+
+        let rendered = '';
+
+        if (i) {
+            rendered += this.EOL;
+        }
+
+        rendered += this.EOL;
+
+        // todo: preserve notes map inside transform
+        // rendered += this.renderContainer(token);
+
+        const type = token.attrGet('note-type');
+        if (!type?.length) {
+            throw new Error("failed to render note, reason: couldn't find note type");
+        }
+
+        rendered += `{% note ${type} `;
+
+        return rendered;
+    },
+    yfm_note_title_open: function (this: MarkdownRenderer) {
+        return '"';
+    },
+    yfm_note_title_close: function (this: MarkdownRenderer) {
+        let rendered = '" %}';
+
+        rendered += this.EOL;
+
+        return rendered;
+    },
+    yfm_note_close: function (this: MarkdownRenderer, tokens: Token[], i: number) {
+        let rendered = '';
+
+        rendered += this.EOL.repeat(2);
+
+        // todo: preserve notes map inside transform
+        // const token = tokens[i];
+        // rendered += this.renderContainer(token);
+
+        rendered += '{% endnote %}';
+
+        rendered += this.EOL;
+
+        if (i + 1 !== tokens.length) {
+            rendered += this.EOL;
+        }
+
+        return rendered;
+    },
+};
+
+export {notes};
+export default {notes};


### PR DESCRIPTION
implemented ability to render diplodoc notes.

discovered roadblock: `transform` plugin for notes looses information about notes line mapping inside the markdown file.

that leads to the problem with notes rendering inside other container blocks(lists).

solution: preserve line mapping information inside the plugin.